### PR TITLE
docs: adjust bilingual switching links format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+English | [中文版本](README_zh.md)
+
 # SimpleLog4sh
 
 ![Log file screenshot](doc/img/header.png)
@@ -29,8 +31,6 @@ Example output:
 2015-08-26 20:12:21 [test.sh] (INFO) hello, world
 2015-08-26 20:12:21 [test.sh] (DEBUG) hello, world
 ```
-
-[中文版本](README_zh.md)
 
 # Usage Examples
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-# [English Version](README.md)
+[English Version](README.md) | 中文
 
 # SimpleLog4sh
 日志文件截图：
@@ -34,10 +34,10 @@ logDebug "hello, world" # 推荐将所有的内容用双引号包围
 
 # 使用方法举例
 ## 导入simpleLog4sh
-在您的shell开头导入即可，可以参考`/example/quickstart`的中的用法：
+在您的shell开头导入即可，可以参考`/examples/quickstart`的中的用法：
 
 ```
-. ../src/simplelog4sh.sh
+. ../src/simpleLog4sh.source
 ```
 
 如果需要覆盖默认配置，可提供配置文件（参考源码中提供的cfg文件）


### PR DESCRIPTION
This PR adjusts the bilingual switching links format as requested:

- **English README**: Shows "English" (no link) + "[中文版本](README_zh.md)" (with link)
- **Chinese README**: Shows "[English Version](README.md)" (with link) + "中文" (no link)

This provides a cleaner language switching experience where the current language is displayed as plain text and the other language is linked.